### PR TITLE
undo bugfix of PR #12: it introduces problems in the Time projects

### DIFF
--- a/script/core/benchmarks/Defects4J.py
+++ b/script/core/benchmarks/Defects4J.py
@@ -189,7 +189,7 @@ defects4j info -p %s -b %s;
         libs_path = os.path.join(self.path, "framework", "projects", bug.project, "lib")
         for (root, _, files) in os.walk(libs_path):
             for f in files:
-                if f not in libs:
+                if f in libs:
                     classpath += ":" + (os.path.join(root, f))
         libs_path = os.path.join(self.path, "framework", "projects", "lib")
         for (root, _, files) in os.walk(libs_path):


### PR DESCRIPTION
By undoing this patch, Time project works again, but some Math (e,g, 104) will fail.