### PR TITLE
print_bugs_available.py output vs. IntroClassJava.py input

### DIFF
--- a/script/core/benchmarks/IntroClassJava.py
+++ b/script/core/benchmarks/IntroClassJava.py
@@ -37,28 +37,23 @@ class IntroClassJava(Benchmark):
                     revision_path = os.path.join(user_path, revision)
                     if os.path.isfile(revision_path):
                         continue
-                    bug = Bug(self, project, "%s_%s" % (user, revision))
+                    bug = Bug(self, project, "%s-%s" % (user, revision))
                     self.bugs += [bug]
         return self.bugs
 
     def get_bug(self, bug_id):
-        separator = "-"
-        if "_" in bug_id:
-            separator = "_"
-        elif "/" in bug_id:
-            separator = "/"
-        (project, user, revision) = bug_id.split(separator)
+        (project, user, revision) = bug_id.split("-")
 
         for bug in self.get_bugs():
             if project != bug.project:
                 continue
-            (bug_user, bug_revision) = bug.bug_id.split("_")
+            (bug_user, bug_revision) = bug.bug_id.split("-")
             if user in bug_user and int(revision) == int(bug_revision):
                 return bug
         return None
 
     def checkout(self, bug, working_directory):
-        user, revision = bug.bug_id.split("_")
+        user, revision = bug.bug_id.split("-")
         bug_path = os.path.join(self.path, "dataset", bug.project, user, revision)
         shutil.copytree(bug_path, working_directory)
         pass
@@ -74,7 +69,7 @@ class IntroClassJava(Benchmark):
         pass
 
     def failing_tests(self, bug):
-        (bug_user, bug_revision) = bug.bug_id.split("_")
+        (bug_user, bug_revision) = bug.bug_id.split("-")
         bug_user = bug_user[:8]
         tests = [
             "introclassJava.%s_%s_%sBlackboxTest" % (bug.project.lower(), bug_user, bug_revision),


### PR DESCRIPTION
The output of `script/print_bugs_available.py` does not match the expected input of `script/core/benchmarks/IntroClassJava.py`. The bug identifier returned by `script/print_bugs_available.py` follows the following format:
```python
    		print bug.project + '-' + str(bug.bug_id)
```
whereas `script/core/benchmarks/IntroClassJava.py` expects a string composed by `project`, `user`, and `revision` (**all** separated by either "-", "_", or "/").
```python
        separator = "-"
        if "_" in bug_id:
            separator = "_"
        elif "/" in bug_id:
            separator = "/"
        (project, user, revision) = bug_id.split(separator)
```

Here is the step-by-step to reproduce the issue:
```
$ python script/print_bugs_available.py -b IntroClassJava
grade-75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356_003
...
digits-c5d8f924b86adfeafa7f520559aeb8bd0c3c178efe2500c4054c5ce51bcdbfc2da2e3d9fd5c73f559a7cb6c3b3555b04646111404744496cbcf31caa90e5beb4_003
...
checksum-659a7300715ba902aeff0650acdfd6e5490cb33ba64d3688555102b2f3f78715368c38fede9c8bb9d23d8041c3db5332ca2877b26bd53f165ff52ceec2022604_003

$ python script/repair.py Kali --benchmark IntroClassJava --id digits-c5d8f924b86adfeafa7f520559aeb8bd0c3c178efe2500c4054c5ce51bcdbfc2da2e3d9fd5c73f559a7cb6c3b3555b04646111404744496cbcf31caa90e5beb4_003
Traceback (most recent call last):
  File "script/repair.py", line 21, in <module>
    bugs.append(args.benchmark.get_bug(bug_id))
  File "/tmp/RepairThemAllFramework/script/core/benchmarks/IntroClassJava.py", line 50, in get_bug
    (project, user, revision) = bug_id.split(separator)
ValueError: need more than 2 values to unpack
```