### PR TITLE
Config options can be set via environment variables

### DIFF
--- a/script/config.py
+++ b/script/config.py
@@ -5,21 +5,21 @@ from core.Support import getGridTime
 REPAIR_ROOT = os.path.join(os.path.dirname(__file__), '..')
 DATA_PATH = os.path.join(REPAIR_ROOT, "data")
 REPAIR_TOOL_FOLDER = os.path.join(REPAIR_ROOT, "repair_tools")
-WORKING_DIRECTORY = os.path.join("/tmp/")
-OUTPUT_PATH = os.path.join(REPAIR_ROOT, "results/")
+WORKING_DIRECTORY = os.environ.get("WORKING_DIRECTORY", expanduser("~/repair/"))
+OUTPUT_PATH = os.environ.get("OUTPUT_PATH", expanduser("~/repair/results"))
 
 Z3_PATH = os.path.join(REPAIR_ROOT, "libs", "z3", "build")
 
-MAVEN_BIN = expanduser("/home/tdurieux/maven/bin")
+MAVEN_BIN = os.environ.get("MAVEN_BIN", expanduser("~/repair/deps/Maven/apache-maven/bin/"))
 
-JAVA7_HOME = expanduser("/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/")
-JAVA8_HOME = expanduser("/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/")
-JAVA_ARGS = "-Xmx4g -Xms1g"
+JAVA7_HOME = os.environ.get("JAVA7_HOME", expanduser("/usr/lib/jvm/java-1.7.0/bin/"))
+JAVA8_HOME = os.environ.get("JAVA8_HOME", expanduser("~/repair/deps/jdk-8/bin"))
+JAVA_ARGS = os.environ.get("JAVA_ARGS", "-Xmx4g -Xms1g")
 
-LOCAL_THREAD = 1
+LOCAL_THREAD = int(os.environ.get("THREADS", "1"))
 GRID5K_MAX_NODE = 50
 ##In minutes
-TOOL_TIMEOUT = "120"
+TOOL_TIMEOUT = os.environ.get("TOOL_TIMEOUT", "120")
 #Format: HH:MM ## the fuction getGridTime calculates the timeout of the grid taking into account an overhead (expressed as percentage)
 GRID5K_TIME_OUT = getGridTime(TOOL_TIMEOUT, overhead=0.33)
 

--- a/script/core/renderer/renderer.py
+++ b/script/core/renderer/renderer.py
@@ -5,7 +5,7 @@ from EmptyRenderer import EmptyRenderer
 
 
 def is_grid5k_node():
-    return 'OAR_JOB_ID' in os.environ
+    return 'OAR_JOB_ID' in os.environ or 'NO_FANCY_OUTPUT' in os.environ
 
 
 def get_renderer(runner):


### PR DESCRIPTION
Several of the config options can be passed via environment variables (see config.py to list them all).

Besides the OAR environment variable (from Grid5K, I assume), you can also se NO_FANCY_OUTPUT to replace CLIRenderer with the Empty one.