### PR TITLE
Fix a bug in Bears failing_tests()

### DIFF
--- a/script/core/benchmarks/Bears.py
+++ b/script/core/benchmarks/Bears.py
@@ -166,7 +166,7 @@ mvn test -V -B -Denforcer.skip=true -Dcheckstyle.skip=true -Dcobertura.skip=true
                 if bug.project.lower() == project_id.lower() and bug.bug_id.lower() == bug_id.lower():
                     for t in b['tests']['failingClasses']:
                         tests += [t['testClass']]
-                        return tests
+                    return tests
         return tests
 
     def failing_module(self, bug):


### PR DESCRIPTION
The following bugs in Bears dataset have more than one failing test:
FasterXML-jackson-databind 195752461-195777970
FasterXML-jackson-databind 241063530-241065840
INRIA-spoon 191511078-191595944
INRIA-spoon 199972949-199993301
INRIA-spoon 199993301-200108848
INRIA-spoon 201940544-203101555
INRIA-spoon 204567691-207361743
INRIA-spoon 211342085-211425556
INRIA-spoon 232723487-232809734
INRIA-spoon 234612953-235302726
INRIA-spoon 237507053-237511642
INRIA-spoon 237627560-237821366
INRIA-spoon 238234811-238235509
INRIA-spoon 245682273-245809519
INRIA-spoon 247837075-247951830
traccar-traccar 207561899-207563891
traccar-traccar 255051210-255052458
2018swecapstone-h2ms 363210218-363627522
Activiti-Activiti 357660134-359342518
aicis-fresco 363993941-363994940
aicis-fresco 370467437-370477490
SzFMV2018-Tavasz-AutomatedCar 367688128-367699437
debezium-debezium 437012651-437020051
FasterXML-jackson-dataformats-text 430357777-445435582
INRIA-spoon 431601111-431664501
INRIA-spoon 453383968-453477713
lettuce-io-lettuce-core 438538449-438808943
raphw-byte-buddy 432194751-432199042
spring-projects-spring-data-commons 458393275-458823066
vkostyukov-la4j 414793864-436911083

Therefore, the `return tests` should have a correct identation. 